### PR TITLE
fix

### DIFF
--- a/app/api/random-station/route.ts
+++ b/app/api/random-station/route.ts
@@ -12,20 +12,55 @@ interface PlaceResult {
       lng: number;
     };
   };
+  opening_hours?: {
+    open_now: boolean;
+    weekday_text?: string[];
+  };
+  price_level?: number;
 }
 
-async function getNearbyPlaces(lat: number, lng: number, type: string, limit: number): Promise<Spot[]> {
-  const url = `https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${lat},${lng}&radius=1000&type=${type}&language=ja&key=${process.env.GOOGLE_PLACES_API_KEY}`
+async function getNearbyPlaces(lat: number, lng: number, type: string, keyword: string | null = null): Promise<Spot[]> {
+  let url = `https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=${lat},${lng}&radius=1000&language=ja&key=${process.env.GOOGLE_MAPS_API_KEY}`
+  
+  if (type !== 'public_bath') {
+    url += `&type=${type}`
+  } else if (keyword) {
+    url += `&keyword=${encodeURIComponent(keyword)}`
+  }
+
   const response = await fetch(url)
   const data = await response.json()
-  return data.results.slice(0, limit).map((place: PlaceResult) => ({
-    id: place.place_id,
-    name: place.name,
-    type: type,
-    photo: place.photos ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${place.photos[0].photo_reference}&key=${process.env.GOOGLE_PLACES_API_KEY}` : null,
-    lat: place.geometry.location.lat,
-    lng: place.geometry.location.lng
-  }))
+  
+  return data.results.map((place: PlaceResult) => {
+    const spot: Spot = {
+      id: place.place_id,
+      name: place.name,
+      type: type,
+      photo: place.photos ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${place.photos[0].photo_reference}&key=${process.env.GOOGLE_MAPS_API_KEY}` : null,
+      lat: place.geometry.location.lat,
+      lng: place.geometry.location.lng
+    }
+
+    if (type === 'public_bath') {
+      spot.openingHours = place.opening_hours?.weekday_text ? place.opening_hours.weekday_text.join(', ') : undefined
+      spot.price = place.price_level ? place.price_level * 200 + 300 : undefined
+    }
+
+    return spot
+  })
+}
+
+function areLocationsSame(spot1: Spot, spot2: Spot): boolean {
+  return spot1.lat === spot2.lat && spot1.lng === spot2.lng
+}
+
+function findUniqueSpot(spots: Spot[], selectedSpots: Spot[]): Spot | null {
+  for (const spot of spots) {
+    if (!selectedSpots.some(selectedSpot => areLocationsSame(selectedSpot, spot))) {
+      return spot
+    }
+  }
+  return null
 }
 
 export async function GET() {
@@ -34,32 +69,49 @@ export async function GET() {
       throw new Error('駅データが見つかりません')
     }
 
-    // ランダムに駅を選択
     const randomStationData = stationsData[Math.floor(Math.random() * stationsData.length)]
     const randomStation: Station = {
       ...randomStationData,
-      spots: [],  // Initialize with an empty array
-      passengers: randomStationData.passengers ?? undefined,  // Convert null to undefined if necessary
-      firstDeparture: randomStationData.firstDeparture ?? undefined  // Convert null to undefined if necessary
+      spots: [],
+      passengers: randomStationData.passengers ?? undefined,
+      firstDeparture: randomStationData.firstDeparture ?? undefined
     }
 
     if (!randomStation) {
       throw new Error('駅が見つかりません')
     }
 
-    // 周辺のスポットを取得
-    const touristSpots = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'tourist_attraction', 2)
-    const cafes = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'cafe', 1)
-    const restaurants = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'restaurant', 1)
+    const touristSpots = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'tourist_attraction')
+    const cafes = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'cafe')
+    const restaurants = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'restaurant')
+    const publicBaths = await getNearbyPlaces(randomStation.lat, randomStation.lng, 'public_bath', '銭湯 OR 温泉')
 
-    // スポットをシャッフルして重複を避ける
-    const allSpots = [...touristSpots, ...cafes, ...restaurants]
-    const shuffledSpots = allSpots.sort(() => Math.random() - 0.5)
-    const uniqueSpots = Array.from(new Set(shuffledSpots.map(s => s.name)))
-      .map(name => shuffledSpots.find(s => s.name === name))
-      .slice(0, 4)
+    const allSpots = [...touristSpots, ...cafes, ...restaurants, ...publicBaths]
 
-    randomStation.spots = uniqueSpots as Spot[]
+    const selectedSpots: Spot[] = []
+    const categories = ['cafe', 'restaurant', 'public_bath', 'tourist_attraction']
+
+    for (const category of categories) {
+      if (selectedSpots.length < 4) {
+        const spotsInCategory = allSpots.filter(spot => spot.type === category)
+        const uniqueSpot = findUniqueSpot(spotsInCategory, selectedSpots)
+        if (uniqueSpot) {
+          selectedSpots.push(uniqueSpot)
+        }
+      }
+    }
+
+    // If we still don't have 4 spots, fill with any remaining spots
+    while (selectedSpots.length < 4) {
+      const uniqueSpot = findUniqueSpot(allSpots, selectedSpots)
+      if (uniqueSpot) {
+        selectedSpots.push(uniqueSpot)
+      } else {
+        break
+      }
+    }
+
+    randomStation.spots = selectedSpots
 
     return NextResponse.json(randomStation)
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
   const pickStation = async (stationId?: string) => {
     setLoading(true)
     setStation(null)
-    setSelectedSpot(null) // Reset selectedSpot when picking a new station
+    setSelectedSpot(null)
     setError(null)
     try {
       const url = stationId 

--- a/components/map.tsx
+++ b/components/map.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { getGoogleMapsLoader } from '@/lib/google-maps-loader'
 import { Spot } from '@/types/station'
+import { Loader } from '@googlemaps/js-api-loader'
 
 interface MapProps {
   center: {
@@ -57,8 +58,10 @@ export default function Map({ center, selectedSpot }: MapProps) {
               icon: 'http://maps.google.com/mapfiles/ms/icons/blue-dot.png'
             })
 
+            let infoContent = `<div><strong>${selectedSpot.name}</strong><br>${selectedSpot.type}</div>`
+
             const infoWindow = new maps.InfoWindow({
-              content: `<div><strong>${selectedSpot.name}</strong><br>${selectedSpot.type}</div>`
+              content: infoContent
             })
 
             infoWindow.open(map, spotMarker)

--- a/components/spot-card.tsx
+++ b/components/spot-card.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card"
-import { MapPin, Camera, Coffee, Utensils } from 'lucide-react'
+import { MapPin, Camera, Coffee, Utensils, Droplet } from 'lucide-react'
 import Image from 'next/image'
 
 interface SpotCardProps {
@@ -18,6 +18,8 @@ export function SpotCard({ name, type, photo, onClick }: SpotCardProps) {
         return <Coffee className="w-4 h-4" />;
       case 'restaurant':
         return <Utensils className="w-4 h-4" />;
+      case 'public_bath':
+        return <Droplet className="w-4 h-4" />;
       default:
         return <MapPin className="w-4 h-4" />;
     }
@@ -31,6 +33,8 @@ export function SpotCard({ name, type, photo, onClick }: SpotCardProps) {
         return 'カフェ';
       case 'restaurant':
         return 'レストラン';
+      case 'public_bath':
+        return '銭湯';
       default:
         return type;
     }

--- a/types/station.ts
+++ b/types/station.ts
@@ -5,17 +5,19 @@ export interface Station {
   lat: number
   lng: number
   spots?: Spot[]
-  passengers?: number | null  // Allow null for passengers
-  firstDeparture?: string | null  // Allow null for firstDeparture
+  passengers?: number | null
+  firstDeparture?: string | null
 }
 
 export interface Spot {
   id: string
   name: string
-  type: "tourist_attraction" | "cafe" | "restaurant"
+  type: "tourist_attraction" | "cafe" | "restaurant" | "public_bath"
   photo: string | null
   lat: number
   lng: number
+  price?: number
+  openingHours?: string
 }
 
 export interface VisitInfo {


### PR DESCRIPTION
- おすすめスポットに周辺の銭湯を追加
- おすすめスポットの条件を”徒歩20分以内”から”1km以内”に変更してAPIへのアクセス数を軽減